### PR TITLE
Fix NPE in PropertiesSemanticCheck

### DIFF
--- a/prism/src/parser/visitor/PropertiesSemanticCheck.java
+++ b/prism/src/parser/visitor/PropertiesSemanticCheck.java
@@ -206,7 +206,7 @@ public class PropertiesSemanticCheck extends SemanticCheck
 	public void visitPost(ExpressionStrategy e) throws PrismLangException
 	{
 		// Make sure any player names in a coalition operator are valid
-		if (e.getCoalition() != null) {
+		if (e.getCoalition() != null && !e.getCoalition().isAllPlayers()) {
 			for (String player : e.getCoalitionPlayers()) {
 				int numPlayers = modelInfo.getNumPlayers();
 				// Valid player references are either integers


### PR DESCRIPTION
For properties using `<<*>>...`, i.e., an all-player coalition, the semantics check throws a null-pointer exception.

As the check only checks for valid player indices/names, in this case we can just skip the check.