### PR TITLE
PrismCL: Allow overriding the model type to a game (STPG, SMG)

### DIFF
--- a/prism/src/parser/PrismParser.java
+++ b/prism/src/parser/PrismParser.java
@@ -153,7 +153,7 @@ public class PrismParser implements PrismParserConstants {
                 }
                 // Override type of model if requested
                 if (typeOverride != null) {
-                        mf.setModelType(typeOverride);
+                        mf.overrideModelType(typeOverride);
                 }
 
                 return mf;

--- a/prism/src/parser/PrismParser.jj
+++ b/prism/src/parser/PrismParser.jj
@@ -185,7 +185,7 @@ public class PrismParser
 		}
 		// Override type of model if requested
 		if (typeOverride != null) {
-			mf.setModelType(typeOverride);
+			mf.overrideModelType(typeOverride);
 		}
 		
 		return mf;

--- a/prism/src/parser/ast/Player.java
+++ b/prism/src/parser/ast/Player.java
@@ -53,6 +53,25 @@ public class Player extends ASTElement
 		actions = new ArrayList<String>();
 	}
 
+	/**
+	 * Generate the specification for a single player that controls all modules/actions
+	 * in the given ModulesFile.
+	 */
+	public static Player singlePlayerForEverything(ModulesFile mf)
+	{
+		Player player = new Player("p1");
+
+		for (int i = 0; i < mf.getNumModules(); i++) {
+			player.addModule(mf.getModuleName(i));
+		}
+
+		for (String a : mf.getSynchs()) {
+			player.addAction(a);
+		}
+
+		return player;
+	}
+
 	// Set methods
 
 	public void addModule(String moduleName)

--- a/prism/src/prism/PrismCL.java
+++ b/prism/src/prism/PrismCL.java
@@ -1294,6 +1294,14 @@ public class PrismCL implements PrismModelListener
 				else if (sw.equals("ctmc")) {
 					typeOverride = ModelType.CTMC;
 				}
+				// override model type to stpg
+				else if (sw.equals("stpg")) {
+					typeOverride = ModelType.STPG;
+				}
+				// override model type to smg
+				else if (sw.equals("smg")) {
+					typeOverride = ModelType.SMG;
+				}
 
 				// EXPORT OPTIONS:
 
@@ -2335,6 +2343,8 @@ public class PrismCL implements PrismModelListener
 		mainLog.println("-dtmc .......................... Force imported/built model to be a DTMC");
 		mainLog.println("-ctmc .......................... Force imported/built model to be a CTMC");
 		mainLog.println("-mdp ........................... Force imported/built model to be an MDP");
+		mainLog.println("-stpg .......................... Force imported/built model to be an STPG");
+		mainLog.println("-smg ........................... Force imported/built model to be an SMG");
 		mainLog.println();
 		mainLog.println("EXPORT OPTIONS:");
 		mainLog.println("-exportresults <file[:options]>  Export the results of model checking to a file");


### PR DESCRIPTION
Similar to the normal command-line overrides (e.g., -mdp), allow the use of -smg/-stpg to convert a non-game model to a game. Essentially, this creates a single player that controls all non-determinism.

This allows to more conveniently verify/compute advanced properties that are available for games but have not yet been ported for MDPs/DTMCs.